### PR TITLE
Add Dockerfile to run bot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.13-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+
+RUN python -m pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD ["python", "app.py"]


### PR DESCRIPTION
Adds a small Dockerfile that can be used as a runner for the bot (built docker image size: 161 MB)